### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple command line utility to make DNS lookups. Supports all known DNS protocol
     ```
 * From source:
     ```
-    go get github.com/ameshkov/dnslookup
+    go install github.com/ameshkov/dnslookup@latest
     ```
 * You can get a binary from the [releases page](https://github.com/ameshkov/dnslookup/releases).
 * You can install it from the [Snap Store](https://snapcraft.io/dnslookup)


### PR DESCRIPTION
'go get' has been [depreciated](https://go.dev/doc/go-get-install-deprecation) in favour of 'go install' as of Go 1.17.