### PR TITLE
Elapsed time in JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # dnslookup
 
 Simple command line utility to make DNS lookups. Supports all known DNS
-protocols: plain DNS, DoH, DoT, DoQ, DNSCrypt.
+protocols: plain DNS, plain DNS-over-TCP, DoH, DoT, DoQ, DNSCrypt.
 
 ### How to install
 
@@ -33,6 +33,12 @@ Plain DNS:
 
 ```shell
 dnslookup example.org 94.140.14.14
+```
+
+Plain DNS-over-TCP:
+
+```shell
+dnslookup example.org tcp://94.140.14.14
 ```
 
 DNS-over-TLS:

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-    "bytes"
 
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/AdguardTeam/golibs/log"
@@ -172,23 +172,23 @@ func main() {
 		os.Stdout.WriteString(msg)
 		os.Stdout.WriteString(reply.String() + "\n")
 	} else {
-        // Prevent JSON parsing from skewing results
-        endTime := time.Now()
+		// Prevent JSON parsing from skewing results
+		endTime := time.Now()
 
 		var b []byte
-        var prettyJSON bytes.Buffer
+		var prettyJSON bytes.Buffer
 
 		b, err = json.Marshal(reply)
 		if err != nil {
 			log.Fatalf("Cannot marshal reply: %s", err)
 		}
 
-        var elapsedTime = fmt.Sprintf(",\"ElapsedTime\":%f}", float64(endTime.Sub(startTime)) / float64(time.Millisecond))
-        b = append(b[:len(b)-1], elapsedTime...)
+		var elapsedTime = fmt.Sprintf(",\"ElapsedTime\":%f}", float64(endTime.Sub(startTime))/float64(time.Millisecond))
+		b = append(b[:len(b)-1], elapsedTime...)
 
-        if err := json.Indent(&prettyJSON, []byte(b), "", "  "); err != nil {
+		if err := json.Indent(&prettyJSON, []byte(b), "", "  "); err != nil {
 			log.Fatalf("Cannot pretty print reply: %s", err)
-        }
+		}
 
 		os.Stdout.WriteString(prettyJSON.String() + "\n")
 	}
@@ -298,7 +298,7 @@ func getRRType() (rrType uint16) {
 func usage() {
 	os.Stdout.WriteString("Usage: dnslookup <domain> <server> [<providerName> <serverPk>]\n")
 	os.Stdout.WriteString("<domain>: mandatory, domain name to lookup\n")
-    os.Stdout.WriteString("<server>: mandatory, server address. Supported: plain, tcp:// (TCP), tls:// (DOT), https:// (DOH), sdns:// (DNSCrypt), quic:// (DOQ)\n")
+	os.Stdout.WriteString("<server>: mandatory, server address. Supported: plain, tcp:// (TCP), tls:// (DOT), https:// (DOH), sdns:// (DNSCrypt), quic:// (DOQ)\n")
 	os.Stdout.WriteString("<providerName>: optional, DNSCrypt provider name\n")
 	os.Stdout.WriteString("<serverPk>: optional, DNSCrypt server public key\n")
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-type JSONMsg struct {
+type jsonMsg struct {
 	dns.Msg
 	Elapsed time.Duration `json:"elapsed"`
 }
@@ -179,7 +179,7 @@ func main() {
 		// Prevent JSON parsing from skewing results
 		endTime := time.Now()
 
-		var JSONreply JSONMsg
+		var JSONreply jsonMsg
 		JSONreply.Msg = *reply
 		JSONreply.Elapsed = endTime.Sub(startTime)
 


### PR DESCRIPTION
First I would love to say thank you for this wonderful tool. I use it all the time.

One thing I use it for is to do health checks on our caching resolvers, and something I wanted to do was to monitor how long those queries took. But noticed ElapsedTime is only available in the human readable output.

Please forgive me as the last meaningful Go that I wrote was in 2018, and even then my Go skills were quite limited.

My first instinct was to modify the output string slice before printing as follows

```
var elapsed = fmt.Sprintf(",\n  \"ElapsedTime\": %f \n}", float64(time.Now().Sub(startTime)) / float64(time.Millisecond))
b = append(b[:len(b)-2], elapsed...)
```

But I didn't feel comfortable editing formatted JSON, because it could conflict with future changes. So I went with the sjson package as follows

```
import "github.com/tidwall/sjson"

c, err := sjson.Set(string(b), "ElapsedTime", float64(endTime.Sub(startTime)) / float64(time.Millisecond))
if err != nil {
    log.Fatalf("Cannot append elapsed time: %s", err)
}

if err := json.Indent(&prettyJSON, []byte(c), "", "  "); err != nil {
    log.Fatalf("Cannot pretty print reply: %s", err)
}

os.Stdout.WriteString(prettyJSON.String() + "\n")
```

After that I ended up dropping the sjson requirement, editing compact JSON directly and then formatting the JSON output.

Also, one thing I wanted to monitor was plain DNS-over-TCP, which my script used dig for since I didn't know it was supported by dnslookup. But when when I saw https://pkg.go.dev/github.com/AdguardTeam/dnsproxy/upstream#AddressToUpstream I realized it was possible and after testing it does indeed work. So I thought it would be a good idea to expose it in the README