### PR TITLE
DO without EDNS

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,18 +149,17 @@ func main() {
 		{Name: domain + ".", Qtype: rrType, Qclass: class},
 	}
 
+	opt := getOrCreateOpt(req, do)
+
 	if subnetOpt != nil {
-		opt := getOrCreateOpt(req, do)
 		opt.Option = append(opt.Option, subnetOpt)
 	}
 
 	if ednsOpt != nil {
-		opt := getOrCreateOpt(req, do)
 		opt.Option = append(opt.Option, ednsOpt)
 	}
 
 	if padding {
-		opt := getOrCreateOpt(req, do)
 		opt.Option = append(opt.Option, newEDNS0Padding(req))
 	}
 


### PR DESCRIPTION
Allow setting the do flag without having to explicitly enable an EDNS option.

Sometimes we would like to validate DNSSEC but not enable PADDING or any of the other options

Also this way padding won't override edns and they won't override subnet