### PR TITLE
Ensure upstream is closed properly in main function

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot create an upstream: %s", err)
 	}
+	defer func() {
+		_ = u.Close()
+	}()
 
 	req := &dns.Msg{}
 	req.Id = dns.Id()


### PR DESCRIPTION
Dnslookup doesn't close the upstream handle. This can lead to ICMP port unreachable errors from client to server. 

I assume that dnslookup already exits before the quic sessions is terminated. The server then wants to close the connection and because the socket is already closed the kernel sends the ICMP unreachables.

After ensuring that dnslookup closes the handle before it exits I only rarely see ICMP unreachables.

### Reproducer 
The ICMP unreachables can reproduced with these commands:

```bash
sudo tcpdump -i {outgoing interface} -np host 9.9.9.9
dnslookup example.com quic://9.9.9.9
```

Without the patch I see these in tcpdump:
```tcpdump
14:18:28 IP 192.168.x.y  > 9.9.9.9: ICMP 192.168.34.170 udp port 46103 unreachable, length 130
14:18:28 IP 192.168.x.y  > 9.9.9.9: ICMP 192.168.34.170 udp port 46103 unreachable, length 130
14:18:28 IP 192.168.x.y  > 9.9.9.9: ICMP 192.168.34.170 udp port 46103 unreachable, length 63
14:18:29 IP 192.168.x.y  > 9.9.9.9: ICMP 192.168.34.170 udp port 46103 unreachable, length 130
14:18:29 IP 192.168.x.y  > 9.9.9.9: ICMP 192.168.34.170 udp port 46103 unreachable, length 63
```
